### PR TITLE
Tile corners and annotations fixes 

### DIFF
--- a/interchange/DeviceResources.capnp
+++ b/interchange/DeviceResources.capnp
@@ -209,6 +209,15 @@ struct Device {
     # If sub-tiles are not used; then this list is empty and an implicit
     # sub-tile index 0 has the same prefix as the tile name.
     subTilesPrefices @6 : List(StringIdx) $stringRef();
+
+    # Positive and negative offsets are used if tile spans over
+    # multiple grid columns and rows,like Xilinx BRAMs or PCIE hard blocks.
+    # Negative pair is used to calculate upper-left corner
+    # and positive pair is used to calculate lower-right corner of tile
+    rowPosOff     @7 : UInt16;
+    colPosOff     @8 : UInt16;
+    rowNegOff     @9 : UInt16;
+    colNegOff     @10 : UInt16;
   }
 
   ######################################

--- a/interchange/DeviceResources.capnp
+++ b/interchange/DeviceResources.capnp
@@ -59,9 +59,8 @@ annotation wireRef(*) :WireRef;
 using WireIdx = UInt32;
 
 struct WireTypeRef {
-    type  @0 :Ref.ReferenceType = parent;
+    type  @0 :Ref.ReferenceType = rootValue;
     field @1 :Text = "wireTypes";
-    depth @2 :Int32 = 1;
 }
 annotation wireTypeRef(*) :WireTypeRef;
 using WireTypeIdx = UInt32;
@@ -81,19 +80,15 @@ using TileTypeSiteTypeIdx = UInt32;
 using TileTypeSubTileIdx = UInt16;
 
 struct PIPTimingRef {
-  type  @0 :Ref.ReferenceType = parent;
-  field @1 :Text = "pipTimingList";
-  depth @2 :Int32 = 1;
-
+  type  @0 :Ref.ReferenceType = rootValue;
+  field @1 :Text = "pipTimings";
 }
 annotation pipTimingRef(*) :PIPTimingRef;
 using PipTimingIdx = UInt32;
 
 struct NodeTimingRef {
-  type  @0 :Ref.ReferenceType = parent;
-  field @1 :Text = "nodeTimingList";
-  depth @2 :Int32 = 1;
-
+  type  @0 :Ref.ReferenceType = rootValue;
+  field @1 :Text = "nodeTimings";
 }
 annotation nodeTimingRef(*) :NodeTimingRef;
 using NodeTimingIdx = UInt32;
@@ -632,7 +627,7 @@ struct Device {
   }
 
   struct PinDelay {
-    pin   @0 : BELPinIdx $belPinRef();
+    pin   @0 : BELPinIdx;
     union {
       noClock   @1 : Void;
       clockEdge @2 : ClockEdge;


### PR DESCRIPTION
This PR adds offset for tile corners so that tiles spanning multiple columns and rows can be accurately represented.
Also this PR fixes annotations in DeviceResources