### PR TITLE
docs/conf: update theme colors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,6 +132,8 @@ html_theme = 'sphinx_symbiflow_theme'
 html_theme_options = {
     'repo_name': 'chipsalliance/fpga-interchange-schema',
     'github_url': 'https://github.com/chipsalliance/fpga-interchange-schema',
+    'color_primary': 'indigo',
+    'color_accent': 'blue',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Update the theme colors to (roughly) match the CHIPS Alliance branding, instead of Symbiflow's purple.