### PR TITLE
Adding stub nodes for partially routed nets

### DIFF
--- a/docs/device_resources.md
+++ b/docs/device_resources.md
@@ -333,6 +333,17 @@ Examples:
 An input site pin "I0" would have a site port BEL named "I0" with 1 BEL
 output pin named "I0".
 
+### Partially routed nets
+The schema can represent partially routed nets in a design in at least
+two ways.  First, if contigous routing segments are separated by a
+discontinuity (sometimes referred to as an antenna), these
+disconnected segments can be stored in the `stubs` field of a
+`PhysNet`.  However, some architectures have ways of pre-marking a net
+using individual nodes such as for clock planning and have isolated
+nodes to mark decision paths for later routing.  In this case, these
+isolated nodes should be stored in the `stubNodes` field.  A fully
+routed net, however, would generally not use `stubNodes`.
+
 ## Additional topics
 
 The device resources schema also covers some important data required for

--- a/interchange/PhysicalNetlist.capnp
+++ b/interchange/PhysicalNetlist.capnp
@@ -90,6 +90,7 @@ struct PhysNetlist {
     sources   @1 : List(RouteBranch);
     stubs     @2 : List(RouteBranch);
     type      @3 : NetType = signal;
+    stubNodes @4 : List(PhysNode);
   }
 
   enum NetType {
@@ -150,6 +151,12 @@ struct PhysNetlist {
       isInverting @4 : Bool;
       inverts     @5 : Void;
     }
+  }
+
+  struct PhysNode {
+    tile    @0 : StringIdx $stringRef();
+    wire    @1 : StringIdx $stringRef();
+    isFixed @2 : Bool;
   }
 
   struct SiteInstance {


### PR DESCRIPTION
There is a deficiency in the schema for placed (but not routed) designs, specifically for AMD/Xilinx-targeted devices.  After placement, Vivado will leave individual route nodes as clock tree decision points to enable the router to route the clock tree spine.  Currently, there is no way to represent these individual nodes.  This PR adds that capability as outlined in Xilinx/RapidWright#134 and more recently encountered in Xilinx/RapidWright#464.